### PR TITLE
Inventory Edit Functionality implemented, but issues exist

### DIFF
--- a/server/cmd/api/inventory.go
+++ b/server/cmd/api/inventory.go
@@ -133,9 +133,9 @@ func (srv *Server) InvCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req_item := ent.Item{}
+	reqItem := ent.Item{}
 
-	body_parse_err := json.Unmarshal(req_body, &req_item)
+	body_parse_err := json.Unmarshal(req_body, &reqItem)
 
 	// If any are not present or not do not meet requirements (type for example), BadRequest
 
@@ -147,15 +147,15 @@ func (srv *Server) InvCreate(w http.ResponseWriter, r *http.Request) {
 
 	// Create item in database with name, photo, quantity, store_id, category
 
-	ProductId, err := CreateStripeItem(&req_item)
+	ProductId, err := CreateStripeItem(&reqItem)
 	if err != nil {
 		fmt.Println("Stripe Create didn't work:", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
 
-	fmt.Println("req_item:", req_item.Price, req_item.Name, ProductId.DefaultPrice.ID, req_item.Photo, req_item.Quantity, store_id)
+	fmt.Println("reqItem:", reqItem.Price, reqItem.Name, ProductId.DefaultPrice.ID, reqItem.Photo, reqItem.Quantity, store_id)
 
-	createdItem, create_err := srv.DBClient.Item.Create().SetPrice(float64(req_item.Price)).SetName(req_item.Name).SetStripePriceID(ProductId.DefaultPrice.ID).SetStripeProductID(ProductId.ID).SetPhoto([]byte(req_item.Photo)).SetQuantity(req_item.Quantity).SetStoreID(store_id).Save(ctx)
+	createdItem, create_err := srv.DBClient.Item.Create().SetPrice(float64(reqItem.Price)).SetName(reqItem.Name).SetStripePriceID(ProductId.DefaultPrice.ID).SetStripeProductID(ProductId.ID).SetPhoto([]byte(reqItem.Photo)).SetQuantity(reqItem.Quantity).SetStoreID(store_id).SetCategoryName(reqItem.CategoryName).Save(ctx)
 	// If this create doesn't work, InternalServerError
 	if create_err != nil {
 		fmt.Println("Create didn't work:", create_err)
@@ -176,23 +176,32 @@ func (srv *Server) InvUpdate(w http.ResponseWriter, r *http.Request) {
 
 	// ctx := r.Context()
 
-	// store_id, err := strconv.Atoi(chi.URLParam(r, "store_id"))
+	// Load the message parameters (Name, Photo, Quantity, Category)
+	req_body, err := io.ReadAll(r.Body)
 
-	itemId, err := strconv.Atoi(r.URL.Query().Get("item"))
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		fmt.Println("Server failed to read message body:", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	change, err := strconv.Atoi(r.URL.Query().Get("change"))
-	if err != nil {
+
+	reqItem := ent.Item{}
+
+	body_parse_err := json.Unmarshal(req_body, &reqItem)
+
+	// If any are not present or not do not meet requirements (type for example), BadRequest
+
+	if body_parse_err != nil {
+		fmt.Println("Unmarshalling failed:", body_parse_err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 
 	targetItem, err := srv.DBClient.Item.
 		Query().
-		Where(item.ID(itemId)).
+		Where(item.ID(reqItem.ID)).
 		Only(r.Context())
+
 	if ent.IsNotFound(err) {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
@@ -201,8 +210,7 @@ func (srv *Server) InvUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = targetItem.Update().SetQuantity(targetItem.Quantity - change).
-		Save(r.Context())
+	_, err = targetItem.Update().SetQuantity(reqItem.Quantity).SetName(reqItem.Name).SetPhoto(reqItem.Photo).SetPrice(reqItem.Price).SetCategoryName(reqItem.CategoryName).Save(r.Context())
 
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/server/cmd/api/inventory.go
+++ b/server/cmd/api/inventory.go
@@ -218,17 +218,26 @@ func (srv *Server) InvUpdate(w http.ResponseWriter, r *http.Request) {
 }
 func (srv *Server) InvDelete(w http.ResponseWriter, r *http.Request) {
 
-	store := r.Context().Value("store_var").(*ent.Store)
+	// store := r.Context().Value("store_var").(*ent.Store)
 
-	item_id, err := strconv.Atoi(r.URL.Query().Get("item"))
+	store_id, err := strconv.Atoi(chi.URLParam(r, "store_id"))
+
 	if err != nil {
+		fmt.Println("Store Id parsing failed")
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
+	item_id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil {
+		fmt.Println("Item id parsing failed")
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 
 	err = srv.DBClient.
 		Item.DeleteOneID(item_id).
-		Where(item.StoreID(store.ID)).
+		Where(item.StoreID(store_id)).
 		Exec(r.Context())
 
 	if ent.IsNotFound(err) {

--- a/server/internal/ent/item.go
+++ b/server/internal/ent/item.go
@@ -31,6 +31,8 @@ type Item struct {
 	StripePriceID string `json:"stripe_price_id,omitempty"`
 	// StripeProductID holds the value of the "stripe_product_id" field.
 	StripeProductID string `json:"stripe_product_id,omitempty"`
+	// CategoryName holds the value of the "category_name" field.
+	CategoryName string `json:"category_name,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ItemQuery when eager-loading is set.
 	Edges        ItemEdges `json:"edges"`
@@ -92,7 +94,7 @@ func (*Item) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullFloat64)
 		case item.FieldID, item.FieldQuantity, item.FieldStoreID:
 			values[i] = new(sql.NullInt64)
-		case item.FieldName, item.FieldStripePriceID, item.FieldStripeProductID:
+		case item.FieldName, item.FieldStripePriceID, item.FieldStripeProductID, item.FieldCategoryName:
 			values[i] = new(sql.NullString)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -156,6 +158,12 @@ func (i *Item) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field stripe_product_id", values[j])
 			} else if value.Valid {
 				i.StripeProductID = value.String
+			}
+		case item.FieldCategoryName:
+			if value, ok := values[j].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field category_name", values[j])
+			} else if value.Valid {
+				i.CategoryName = value.String
 			}
 		default:
 			i.selectValues.Set(columns[j], values[j])
@@ -228,6 +236,9 @@ func (i *Item) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("stripe_product_id=")
 	builder.WriteString(i.StripeProductID)
+	builder.WriteString(", ")
+	builder.WriteString("category_name=")
+	builder.WriteString(i.CategoryName)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/server/internal/ent/item/item.go
+++ b/server/internal/ent/item/item.go
@@ -26,6 +26,8 @@ const (
 	FieldStripePriceID = "stripe_price_id"
 	// FieldStripeProductID holds the string denoting the stripe_product_id field in the database.
 	FieldStripeProductID = "stripe_product_id"
+	// FieldCategoryName holds the string denoting the category_name field in the database.
+	FieldCategoryName = "category_name"
 	// EdgeCategory holds the string denoting the category edge name in mutations.
 	EdgeCategory = "category"
 	// EdgeStore holds the string denoting the store edge name in mutations.
@@ -65,6 +67,7 @@ var Columns = []string{
 	FieldStoreID,
 	FieldStripePriceID,
 	FieldStripeProductID,
+	FieldCategoryName,
 }
 
 var (
@@ -119,6 +122,11 @@ func ByStripePriceID(opts ...sql.OrderTermOption) OrderOption {
 // ByStripeProductID orders the results by the stripe_product_id field.
 func ByStripeProductID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStripeProductID, opts...).ToFunc()
+}
+
+// ByCategoryName orders the results by the category_name field.
+func ByCategoryName(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCategoryName, opts...).ToFunc()
 }
 
 // ByCategoryCount orders the results by category count.

--- a/server/internal/ent/item/where.go
+++ b/server/internal/ent/item/where.go
@@ -88,6 +88,11 @@ func StripeProductID(v string) predicate.Item {
 	return predicate.Item(sql.FieldEQ(FieldStripeProductID, v))
 }
 
+// CategoryName applies equality check predicate on the "category_name" field. It's identical to CategoryNameEQ.
+func CategoryName(v string) predicate.Item {
+	return predicate.Item(sql.FieldEQ(FieldCategoryName, v))
+}
+
 // NameEQ applies the EQ predicate on the "name" field.
 func NameEQ(v string) predicate.Item {
 	return predicate.Item(sql.FieldEQ(FieldName, v))
@@ -421,6 +426,71 @@ func StripeProductIDEqualFold(v string) predicate.Item {
 // StripeProductIDContainsFold applies the ContainsFold predicate on the "stripe_product_id" field.
 func StripeProductIDContainsFold(v string) predicate.Item {
 	return predicate.Item(sql.FieldContainsFold(FieldStripeProductID, v))
+}
+
+// CategoryNameEQ applies the EQ predicate on the "category_name" field.
+func CategoryNameEQ(v string) predicate.Item {
+	return predicate.Item(sql.FieldEQ(FieldCategoryName, v))
+}
+
+// CategoryNameNEQ applies the NEQ predicate on the "category_name" field.
+func CategoryNameNEQ(v string) predicate.Item {
+	return predicate.Item(sql.FieldNEQ(FieldCategoryName, v))
+}
+
+// CategoryNameIn applies the In predicate on the "category_name" field.
+func CategoryNameIn(vs ...string) predicate.Item {
+	return predicate.Item(sql.FieldIn(FieldCategoryName, vs...))
+}
+
+// CategoryNameNotIn applies the NotIn predicate on the "category_name" field.
+func CategoryNameNotIn(vs ...string) predicate.Item {
+	return predicate.Item(sql.FieldNotIn(FieldCategoryName, vs...))
+}
+
+// CategoryNameGT applies the GT predicate on the "category_name" field.
+func CategoryNameGT(v string) predicate.Item {
+	return predicate.Item(sql.FieldGT(FieldCategoryName, v))
+}
+
+// CategoryNameGTE applies the GTE predicate on the "category_name" field.
+func CategoryNameGTE(v string) predicate.Item {
+	return predicate.Item(sql.FieldGTE(FieldCategoryName, v))
+}
+
+// CategoryNameLT applies the LT predicate on the "category_name" field.
+func CategoryNameLT(v string) predicate.Item {
+	return predicate.Item(sql.FieldLT(FieldCategoryName, v))
+}
+
+// CategoryNameLTE applies the LTE predicate on the "category_name" field.
+func CategoryNameLTE(v string) predicate.Item {
+	return predicate.Item(sql.FieldLTE(FieldCategoryName, v))
+}
+
+// CategoryNameContains applies the Contains predicate on the "category_name" field.
+func CategoryNameContains(v string) predicate.Item {
+	return predicate.Item(sql.FieldContains(FieldCategoryName, v))
+}
+
+// CategoryNameHasPrefix applies the HasPrefix predicate on the "category_name" field.
+func CategoryNameHasPrefix(v string) predicate.Item {
+	return predicate.Item(sql.FieldHasPrefix(FieldCategoryName, v))
+}
+
+// CategoryNameHasSuffix applies the HasSuffix predicate on the "category_name" field.
+func CategoryNameHasSuffix(v string) predicate.Item {
+	return predicate.Item(sql.FieldHasSuffix(FieldCategoryName, v))
+}
+
+// CategoryNameEqualFold applies the EqualFold predicate on the "category_name" field.
+func CategoryNameEqualFold(v string) predicate.Item {
+	return predicate.Item(sql.FieldEqualFold(FieldCategoryName, v))
+}
+
+// CategoryNameContainsFold applies the ContainsFold predicate on the "category_name" field.
+func CategoryNameContainsFold(v string) predicate.Item {
+	return predicate.Item(sql.FieldContainsFold(FieldCategoryName, v))
 }
 
 // HasCategory applies the HasEdge predicate on the "category" edge.

--- a/server/internal/ent/item_create.go
+++ b/server/internal/ent/item_create.go
@@ -63,6 +63,12 @@ func (ic *ItemCreate) SetStripeProductID(s string) *ItemCreate {
 	return ic
 }
 
+// SetCategoryName sets the "category_name" field.
+func (ic *ItemCreate) SetCategoryName(s string) *ItemCreate {
+	ic.mutation.SetCategoryName(s)
+	return ic
+}
+
 // SetID sets the "id" field.
 func (ic *ItemCreate) SetID(i int) *ItemCreate {
 	ic.mutation.SetID(i)
@@ -144,6 +150,9 @@ func (ic *ItemCreate) check() error {
 	if _, ok := ic.mutation.StripeProductID(); !ok {
 		return &ValidationError{Name: "stripe_product_id", err: errors.New(`ent: missing required field "Item.stripe_product_id"`)}
 	}
+	if _, ok := ic.mutation.CategoryName(); !ok {
+		return &ValidationError{Name: "category_name", err: errors.New(`ent: missing required field "Item.category_name"`)}
+	}
 	if _, ok := ic.mutation.StoreID(); !ok {
 		return &ValidationError{Name: "store", err: errors.New(`ent: missing required edge "Item.store"`)}
 	}
@@ -202,6 +211,10 @@ func (ic *ItemCreate) createSpec() (*Item, *sqlgraph.CreateSpec) {
 	if value, ok := ic.mutation.StripeProductID(); ok {
 		_spec.SetField(item.FieldStripeProductID, field.TypeString, value)
 		_node.StripeProductID = value
+	}
+	if value, ok := ic.mutation.CategoryName(); ok {
+		_spec.SetField(item.FieldCategoryName, field.TypeString, value)
+		_node.CategoryName = value
 	}
 	if nodes := ic.mutation.CategoryIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/server/internal/ent/item_update.go
+++ b/server/internal/ent/item_update.go
@@ -85,6 +85,12 @@ func (iu *ItemUpdate) SetStripeProductID(s string) *ItemUpdate {
 	return iu
 }
 
+// SetCategoryName sets the "category_name" field.
+func (iu *ItemUpdate) SetCategoryName(s string) *ItemUpdate {
+	iu.mutation.SetCategoryName(s)
+	return iu
+}
+
 // AddCategoryIDs adds the "category" edge to the Category entity by IDs.
 func (iu *ItemUpdate) AddCategoryIDs(ids ...int) *ItemUpdate {
 	iu.mutation.AddCategoryIDs(ids...)
@@ -207,6 +213,9 @@ func (iu *ItemUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := iu.mutation.StripeProductID(); ok {
 		_spec.SetField(item.FieldStripeProductID, field.TypeString, value)
+	}
+	if value, ok := iu.mutation.CategoryName(); ok {
+		_spec.SetField(item.FieldCategoryName, field.TypeString, value)
 	}
 	if iu.mutation.CategoryCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -355,6 +364,12 @@ func (iuo *ItemUpdateOne) SetStripePriceID(s string) *ItemUpdateOne {
 // SetStripeProductID sets the "stripe_product_id" field.
 func (iuo *ItemUpdateOne) SetStripeProductID(s string) *ItemUpdateOne {
 	iuo.mutation.SetStripeProductID(s)
+	return iuo
+}
+
+// SetCategoryName sets the "category_name" field.
+func (iuo *ItemUpdateOne) SetCategoryName(s string) *ItemUpdateOne {
+	iuo.mutation.SetCategoryName(s)
 	return iuo
 }
 
@@ -510,6 +525,9 @@ func (iuo *ItemUpdateOne) sqlSave(ctx context.Context) (_node *Item, err error) 
 	}
 	if value, ok := iuo.mutation.StripeProductID(); ok {
 		_spec.SetField(item.FieldStripeProductID, field.TypeString, value)
+	}
+	if value, ok := iuo.mutation.CategoryName(); ok {
+		_spec.SetField(item.FieldCategoryName, field.TypeString, value)
 	}
 	if iuo.mutation.CategoryCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/server/internal/ent/migrate/schema.go
+++ b/server/internal/ent/migrate/schema.go
@@ -70,6 +70,7 @@ var (
 		{Name: "price", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "decimal(10,2)"}},
 		{Name: "stripe_price_id", Type: field.TypeString},
 		{Name: "stripe_product_id", Type: field.TypeString},
+		{Name: "category_name", Type: field.TypeString},
 		{Name: "store_id", Type: field.TypeInt},
 	}
 	// ItemsTable holds the schema information for the "items" table.
@@ -80,7 +81,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "items_stores_items",
-				Columns:    []*schema.Column{ItemsColumns[7]},
+				Columns:    []*schema.Column{ItemsColumns[8]},
 				RefColumns: []*schema.Column{StoresColumns[0]},
 				OnDelete:   schema.NoAction,
 			},

--- a/server/internal/ent/mutation.go
+++ b/server/internal/ent/mutation.go
@@ -1014,6 +1014,7 @@ type ItemMutation struct {
 	addprice          *float64
 	stripe_price_id   *string
 	stripe_product_id *string
+	category_name     *string
 	clearedFields     map[string]struct{}
 	category          map[int]struct{}
 	removedcategory   map[int]struct{}
@@ -1421,6 +1422,42 @@ func (m *ItemMutation) ResetStripeProductID() {
 	m.stripe_product_id = nil
 }
 
+// SetCategoryName sets the "category_name" field.
+func (m *ItemMutation) SetCategoryName(s string) {
+	m.category_name = &s
+}
+
+// CategoryName returns the value of the "category_name" field in the mutation.
+func (m *ItemMutation) CategoryName() (r string, exists bool) {
+	v := m.category_name
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCategoryName returns the old "category_name" field's value of the Item entity.
+// If the Item object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ItemMutation) OldCategoryName(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCategoryName is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCategoryName requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCategoryName: %w", err)
+	}
+	return oldValue.CategoryName, nil
+}
+
+// ResetCategoryName resets all changes to the "category_name" field.
+func (m *ItemMutation) ResetCategoryName() {
+	m.category_name = nil
+}
+
 // AddCategoryIDs adds the "category" edge to the Category entity by ids.
 func (m *ItemMutation) AddCategoryIDs(ids ...int) {
 	if m.category == nil {
@@ -1536,7 +1573,7 @@ func (m *ItemMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ItemMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 8)
 	if m.name != nil {
 		fields = append(fields, item.FieldName)
 	}
@@ -1557,6 +1594,9 @@ func (m *ItemMutation) Fields() []string {
 	}
 	if m.stripe_product_id != nil {
 		fields = append(fields, item.FieldStripeProductID)
+	}
+	if m.category_name != nil {
+		fields = append(fields, item.FieldCategoryName)
 	}
 	return fields
 }
@@ -1580,6 +1620,8 @@ func (m *ItemMutation) Field(name string) (ent.Value, bool) {
 		return m.StripePriceID()
 	case item.FieldStripeProductID:
 		return m.StripeProductID()
+	case item.FieldCategoryName:
+		return m.CategoryName()
 	}
 	return nil, false
 }
@@ -1603,6 +1645,8 @@ func (m *ItemMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldStripePriceID(ctx)
 	case item.FieldStripeProductID:
 		return m.OldStripeProductID(ctx)
+	case item.FieldCategoryName:
+		return m.OldCategoryName(ctx)
 	}
 	return nil, fmt.Errorf("unknown Item field %s", name)
 }
@@ -1660,6 +1704,13 @@ func (m *ItemMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetStripeProductID(v)
+		return nil
+	case item.FieldCategoryName:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCategoryName(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Item field %s", name)
@@ -1757,6 +1808,9 @@ func (m *ItemMutation) ResetField(name string) error {
 		return nil
 	case item.FieldStripeProductID:
 		m.ResetStripeProductID()
+		return nil
+	case item.FieldCategoryName:
+		m.ResetCategoryName()
 		return nil
 	}
 	return fmt.Errorf("unknown Item field %s", name)

--- a/server/internal/ent/schema/item.go
+++ b/server/internal/ent/schema/item.go
@@ -26,6 +26,7 @@ func (Item) Fields() []ent.Field {
 		field.Int("store_id"),
 		field.String("stripe_price_id"),
 		field.String("stripe_product_id"),
+		field.String("category_name"),
 	}
 }
 

--- a/web/src/app/(app-page)/app/hooks/items.tsx
+++ b/web/src/app/(app-page)/app/hooks/items.tsx
@@ -3,7 +3,7 @@ import {useFetch} from "../../../../lib/utils"
 import { auth } from "@clerk/nextjs"
 import {useQuery, useMutation, useQueryClient} from "@tanstack/react-query"
 
-const serverURL = "http://localhost:8080/"// "https://retailgo-production.up.railway.app/"
+const serverURL = "https://retailgo-production.up.railway.app/"
 
 const storeURL = serverURL + "store/"
 

--- a/web/src/components/app-page/inventory-table/data-table.tsx
+++ b/web/src/components/app-page/inventory-table/data-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useDeleteItem } from "@/app/(app-page)/app/hooks/items";
 import {
   ColumnDef,
   ColumnFiltersState,
@@ -38,6 +39,7 @@ export function DataTable<TData extends Item, TValue>({
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const deleteItemMutation = useDeleteItem("1")
 
   const table = useReactTable({
     data,
@@ -105,7 +107,7 @@ export function DataTable<TData extends Item, TValue>({
                   <TableCell>
                     <div className="text-right flex flex-row space-x-2 h-8 w-8 p-0">
                       <ItemDialog item={row.original} mode="edit" />
-                      <button onClick={() => console.log("Delete button clicked")}>
+                      <button onClick={() => deleteItemMutation.mutate(row.original.id)}>
                         <Trash2 style={{ color: "red" }} className="h-5 w-5 p-0"></Trash2>
                       </button>
                     </div>

--- a/web/src/components/app-page/item-dialog.tsx
+++ b/web/src/components/app-page/item-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import {useState} from "react"
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { useFetch } from "../../lib/utils"
@@ -23,7 +24,7 @@ import {
   FormLabel,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Item } from "@/models/item";
+import { Item, ItemWithoutId } from "@/models/item";
 import { useEffect } from "react";
 import { PencilIcon } from "lucide-react";
 
@@ -42,6 +43,7 @@ export default function ItemDialog({ item, mode = 'add' }: { item: Item, mode?: 
 
   const createItemMutation = useCreateItem("1")
   const editItemMutation = useCreateItem("1")
+
 
   return (
     <Dialog>

--- a/web/src/components/app-page/item-dialog.tsx
+++ b/web/src/components/app-page/item-dialog.tsx
@@ -4,7 +4,7 @@ import {useState} from "react"
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { useFetch } from "../../lib/utils"
-import { useCreateItem } from "@/app/(app-page)/app/hooks/items";
+import { useCreateItem, useEditItem } from "@/app/(app-page)/app/hooks/items";
 
 import * as z from "zod";
 
@@ -42,8 +42,12 @@ export default function ItemDialog({ item, mode = 'add' }: { item: Item, mode?: 
   });;
 
   const createItemMutation = useCreateItem("1")
-  const editItemMutation = useCreateItem("1")
+  const editItemMutation = useEditItem("1")
 
+  const [inputName, setInputName] = useState(item.name)
+  const [inputCategory, setInputCategory] = useState(item.category)
+  const [inputPrice, setInputPrice] = useState(item.price)
+  const [inputQuantity, setInputQuantity] = useState(item.quantity)
 
   return (
     <Dialog>
@@ -62,7 +66,11 @@ export default function ItemDialog({ item, mode = 'add' }: { item: Item, mode?: 
       <Form {...form}>
         <form>
           <DialogContent>
-            <form onSubmit = {form.handleSubmit((data) => mode === "edit" ? editItemMutation.mutate(data) : createItemMutation.mutate(data), (data) => console.log("Error:", data))}>
+            <form onSubmit = {form.handleSubmit((data) => {
+              console.log("Data:", data)
+              return mode === "edit" ? editItemMutation.mutate({...item, ...data}) : createItemMutation.mutate(data)
+            }
+              , (data) => console.log("Error:", data, "InputName:", inputName, "inputCategory:", inputCategory, "InputQuantity:", inputQuantity))}>
             <DialogHeader>
               <DialogTitle>
               {mode === "edit" ? 'Edit' : 'Add'} Item
@@ -76,7 +84,7 @@ export default function ItemDialog({ item, mode = 'add' }: { item: Item, mode?: 
                 <FormItem>
                   <FormLabel>Name</FormLabel>
                   <FormControl>
-                    <Input {...field}/>
+                    <Input {...field} value = {inputName} onChange={(e) => setInputName(e.currentTarget.value)}/>
                   </FormControl>
                 </FormItem>
               )}
@@ -89,13 +97,12 @@ export default function ItemDialog({ item, mode = 'add' }: { item: Item, mode?: 
                 <FormItem>
                   <FormLabel>Category</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <Input {...field} value = {inputCategory} onChange={(e) => setInputCategory(e.currentTarget.value)}/>
                   </FormControl>
                 </FormItem>
               )}
             />
-
-
+  
             <FormField
               control={form.control}
               name="price"
@@ -103,7 +110,7 @@ export default function ItemDialog({ item, mode = 'add' }: { item: Item, mode?: 
                 <FormItem>
                   <FormLabel>Price</FormLabel>
                   <FormControl>
-                    <Input {...field} type = "number"/>
+                    <Input {...field} type = "number" value = {inputPrice} onChange={(e) => setInputPrice(parseFloat(e.currentTarget.value))}/>
                   </FormControl>
                 </FormItem>
               )}
@@ -116,7 +123,7 @@ export default function ItemDialog({ item, mode = 'add' }: { item: Item, mode?: 
                 <FormItem>
                   <FormLabel>Quantity</FormLabel>
                   <FormControl>
-                    <Input {...field} type = "number"/>
+                    <Input {...field} type = "number" value = {inputQuantity} onChange={(e) => setInputQuantity(parseInt(e.currentTarget.value))}/>
                   </FormControl>
                 </FormItem>
               )}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -11,12 +11,32 @@ export function cn(...inputs: ClassValue[]) {
 export function useFetch() {
   const { getToken } = useAuth();
  
-  const authenticatedFetch = async (url: string | Request, init?: RequestInit, headers?: any) => {
-    return fetch(url, {
+  const authenticatedFetch = async (url: string | Request, init?: RequestInit, headers?: any, toJSON?: boolean) => {
+    const response = fetch(url, {
       ...init,
       headers: headers !== undefined? {...headers, ...{ Authorization: `Bearer ${await getToken()}` }} : {...headers, ...{ Authorization: `Bearer ${await getToken()}` }}}
-    ).then(res => res.json());
+    )
+    if (toJSON){
+      return response.then(res => res.json())
+    }
+    else{
+      return await response
+    }
   };
- 
+
+// const authenticatedFetch = async (url: string | Request, init?: RequestInit, headers?: any) => {
+//     const response = await fetch(url, {
+//       ...init,
+//       headers: headers !== undefined? {...headers, ...{ Authorization: `Bearer ${await getToken()}` }} : {...headers, ...{ Authorization: `Bearer ${await getToken()}` }}}
+//     );
+
+//     if (!response.ok){
+//       return Promise.reject()
+//     }else{
+//       return response
+//     }
+//   };
+  
+
   return authenticatedFetch;
 }


### PR DESCRIPTION
- Inventory Editing integrated using ReactQuery.
- Issues:
    - If a user doesn't edit all entries in the form upon one invocation of the edit button for an item, the handleSubmit experiences an error like this:
    
`Error: 
{name: {…}, quantity: {…}, category: {…}}
category
: 
{message: 'Required', type: 'invalid_type', ref: {…}}
name
: 
{message: 'Required', type: 'invalid_type', ref: {…}}
quantity
: 
{message: 'Expected number, received nan', type: 'invalid_type', ref: {…}}
[[Prototype]]
: 
Object`

I'm using state to track the values of each input, and these are still set correctly if not updated in the current invocation of the edit, but the handleSubmit still errors.


This is a relatively common bug with some of the websites I've used, so it is at least functional, but hopefully I will fix this shortly.